### PR TITLE
Add navigation unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # personal landing page
+
+## Running tests
+
+```
+node tests/nav.test.js
+```

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -6,7 +6,7 @@ function openNav() {
     document.getElementById("main").style.marginLeft = "20px";
     document.getElementById("overlay").style.width = "100%";
     document.getElementById("overlay").style.height = "100%";
-    document.getElementById("overlay").style.backgroundColor = "rgba(0,0,0,0.4)";            
+    document.getElementById("overlay").style.backgroundColor = "rgba(0,0,0,0.4)";
 }
 
 function closeNav() {
@@ -15,3 +15,9 @@ function closeNav() {
     document.getElementById("overlay").style.width = "0%";
     document.getElementById("overlay").style.height = "0%";
 }
+
+// Export the functions when running in a Node environment
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { openNav, closeNav };
+}
+

--- a/tests/nav.test.js
+++ b/tests/nav.test.js
@@ -1,0 +1,35 @@
+const assert = require('assert');
+
+// Mock document and elements
+const elements = {
+  mySidenav: { style: {} },
+  main: { style: {} },
+  overlay: { style: {} },
+};
+
+global.document = {
+  getElementById: (id) => elements[id],
+};
+
+const { openNav, closeNav } = require('../assets/js/script.js');
+
+// Test openNav behavior
+openNav();
+assert.strictEqual(elements.mySidenav.style.width, '250px');
+assert.strictEqual(elements.main.style.marginLeft, '20px');
+assert.strictEqual(elements.overlay.style.width, '100%');
+assert.strictEqual(elements.overlay.style.height, '100%');
+assert.strictEqual(
+  elements.overlay.style.backgroundColor,
+  'rgba(0,0,0,0.4)'
+);
+
+// Test closeNav resets styles
+closeNav();
+assert.strictEqual(elements.mySidenav.style.width, '0');
+assert.strictEqual(elements.main.style.marginLeft, '0');
+assert.strictEqual(elements.overlay.style.width, '0%');
+assert.strictEqual(elements.overlay.style.height, '0%');
+
+console.log('All nav tests passed.');
+


### PR DESCRIPTION
## Summary
- add test folder and nav.test.js
- export openNav and closeNav for Node testing
- document test command in README

## Testing
- `node tests/nav.test.js`


------
https://chatgpt.com/codex/tasks/task_e_686607db8028832f88ba4aefc1e356fe